### PR TITLE
Specifying the version of Vein in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coffee-script": "*",
     "mongodb": "*",
     "connect": "*",
-    "vein": "*",
+    "vein": "0.3.4",
     "async": "*",
     "mongo-ton": "*",
     "uglify-js": "*"


### PR DESCRIPTION
Specifying the version of Vein in package.json to avoid incompatibilities with newer versions.

This was originally discussed at:
https://github.com/wearefractal/smog/issues/2
