### PR TITLE
Replace username and password with generics when printing to log.

### DIFF
--- a/lib/services/connect.coffee
+++ b/lib/services/connect.coffee
@@ -1,7 +1,8 @@
 mongo = require 'mongoskin'
 
 module.exports = (cb, host) ->
-  console.log "connect #{host}"
+  var safeHost = host.replace(/(\:\/\/)(.*?)(\@)/, "://user:****@");
+  console.log "connect #{safeHost}"
   return cb "Missing connection string" unless typeof host is 'string'
   return cb null, true if cb.socket.mongo?.database?
 


### PR DESCRIPTION
Hide username and password when printing host to logs.
